### PR TITLE
[FEAT] BottomSheet 컴포넌트 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <title>Influy</title>
   </head>
   <body>
-    <div id="modal"></div>
     <div id="root"></div>
+    <div id="modal"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -1,0 +1,144 @@
+import { ReactNode, useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+
+export const ModalPortal = ({ children }: { children: ReactNode }) => {
+  const root = document.getElementById('modal');
+  if (!root) return;
+  return ReactDOM.createPortal(children, root);
+};
+
+interface BottomSheetMetrics {
+  touchStart: {
+    sheetY: number; // 바텀 시트 초기 위치
+    touchY: number; // 사용자가 터치한 위치
+  };
+  snap: number; // 바텀 시트가 닫히는 기준 위치
+  isContentAreaTouched: boolean;
+}
+
+const BottomSheet = ({
+  children,
+  onClose,
+  isBottomSheetOpen,
+}: {
+  children: ReactNode;
+  onClose: () => void;
+  isBottomSheetOpen: boolean;
+}) => {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, []);
+
+  const handleBarRef = useRef<HTMLDivElement>(null);
+
+  const metrics = useRef<BottomSheetMetrics>({
+    touchStart: {
+      sheetY: 0,
+      touchY: 0,
+    },
+    snap: 0,
+    isContentAreaTouched: false,
+  });
+
+  // 스크롤 가능한 부모 요소를 찾음
+  const findScrollableParentElement = (
+    element: HTMLElement | null
+  ): HTMLElement | null => {
+    while (element) {
+      const overflowY = getComputedStyle(element).overflowY;
+      const isScrollable = element.scrollHeight > element.clientHeight;
+      if (isScrollable && overflowY !== 'hidden') {
+        return element;
+      }
+      element = element.parentElement;
+    }
+    return null;
+  };
+
+  useEffect(() => {
+    if (!isBottomSheetOpen) return;
+    const node = handleBarRef.current;
+    if (!node) return;
+    const handleTouchStart = (e: TouchEvent) => {
+      const { touchStart } = metrics.current;
+
+      const target = e.target as HTMLElement;
+      const isScrollable = findScrollableParentElement(target);
+
+      metrics.current.isContentAreaTouched = !!isScrollable; // boolean으로 명시적 반환(요소가 있으면 true)
+
+      touchStart.sheetY = node.getBoundingClientRect().y;
+      touchStart.touchY = e.touches[0].clientY;
+      metrics.current.snap =
+        touchStart.sheetY + (node.getBoundingClientRect().height / 4) * 1;
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      const { touchStart, isContentAreaTouched } = metrics.current;
+      const currentTouch = e.touches[0];
+
+      if (!isContentAreaTouched) {
+        e.preventDefault();
+        const touchOffset = currentTouch.clientY - touchStart.touchY;
+        node.style.setProperty(
+          'transform',
+          `translateY(${Math.max(touchOffset, 0)}px)`
+        );
+      }
+    };
+
+    // 손가락을 뗐을 때의 높이에 따라 닫을지 말지 결정
+    const handleTouchEnd = () => {
+      const { touchStart, snap } = metrics.current;
+      const currentY = node.getBoundingClientRect().y;
+
+      if (currentY > snap) {
+        node.style.setProperty(
+          'transform',
+          `translateY(${window.innerHeight - touchStart.sheetY}px)`
+        );
+        onClose();
+      } else if (currentY < snap) {
+        node.style.setProperty('transform', 'translateY(0px)');
+      }
+
+      metrics.current.isContentAreaTouched = false;
+    };
+    node.addEventListener('touchstart', handleTouchStart);
+    node.addEventListener('touchmove', handleTouchMove);
+    node.addEventListener('touchend', handleTouchEnd);
+
+    return () => {
+      node.removeEventListener('touchstart', handleTouchStart);
+      node.removeEventListener('touchmove', handleTouchMove);
+      node.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [isBottomSheetOpen]);
+
+  return (
+    <ModalPortal>
+      <div className="modal">
+        <div className="modal-bg-layout" onClick={onClose}>
+          <div
+            className="flex h-fit flex-col items-center rounded-t-[12px] bg-white"
+            onClick={(e) => e.stopPropagation()}
+            ref={handleBarRef}
+          >
+            {/* 바텀 시트 헤더 */}
+            <div className="flex w-full justify-center rounded-t-[12px] pt-2 pb-4">
+              <div className="bg-grey02 h-1 w-12 rounded-[2px]" />
+            </div>
+            {/* 바텀 시트 콘텐츠 */}
+            <div className="flex h-fit w-full flex-col">{children}</div>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+};
+
+export default BottomSheet;

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -1,3 +1,4 @@
+import cn from '@/utils/cn';
 import { ReactNode, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -108,6 +109,7 @@ const BottomSheet = ({
 
       metrics.current.isContentAreaTouched = false;
     };
+
     node.addEventListener('touchstart', handleTouchStart);
     node.addEventListener('touchmove', handleTouchMove);
     node.addEventListener('touchend', handleTouchEnd);
@@ -124,7 +126,10 @@ const BottomSheet = ({
       <div className="modal">
         <div className="modal-bg-layout" onClick={onClose}>
           <div
-            className="flex h-fit flex-col items-center rounded-t-[12px] bg-white"
+            className={cn(
+              'flex h-fit flex-col items-center rounded-t-[12px] bg-white',
+              { 'animate-slide-up': isBottomSheetOpen }
+            )}
             onClick={(e) => e.stopPropagation()}
             ref={handleBarRef}
           >

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -1,3 +1,4 @@
+import useBottomSheetGesture from '@/hooks/useBottomSheetGesture';
 import cn from '@/utils/cn';
 import { ReactNode, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
@@ -7,15 +8,6 @@ export const ModalPortal = ({ children }: { children: ReactNode }) => {
   if (!root) return;
   return ReactDOM.createPortal(children, root);
 };
-
-interface BottomSheetMetrics {
-  touchStart: {
-    sheetY: number; // 바텀 시트 초기 위치
-    touchY: number; // 사용자가 터치한 위치
-  };
-  snap: number; // 바텀 시트가 닫히는 기준 위치
-  isContentAreaTouched: boolean;
-}
 
 const BottomSheet = ({
   children,
@@ -34,114 +26,9 @@ const BottomSheet = ({
     };
   }, []);
 
-  const handleBarRef = useRef<HTMLDivElement>(null);
+  const handleBarRef = useRef<HTMLDivElement | null>(null);
 
-  const metrics = useRef<BottomSheetMetrics>({
-    touchStart: {
-      sheetY: 0,
-      touchY: 0,
-    },
-    snap: 0,
-    isContentAreaTouched: false,
-  });
-
-  // 스크롤 가능한 부모 요소를 찾음
-  const findScrollableParentElement = (
-    element: HTMLElement | null
-  ): HTMLElement | null => {
-    while (element) {
-      const overflowY = getComputedStyle(element).overflowY;
-      const isScrollable = element.scrollHeight > element.clientHeight;
-      if (isScrollable && overflowY !== 'hidden') {
-        return element;
-      }
-      element = element.parentElement;
-    }
-    return null;
-  };
-
-  useEffect(() => {
-    if (!isBottomSheetOpen) return;
-    const node = handleBarRef.current;
-    if (!node) return;
-
-    const isDragging = { current: false };
-
-    const handleTouchStart = (e: TouchEvent | MouseEvent) => {
-      const { touchStart } = metrics.current;
-
-      const target = e.target as HTMLElement;
-      const isScrollable = findScrollableParentElement(target);
-
-      metrics.current.isContentAreaTouched = !!isScrollable; // boolean으로 명시적 반환(요소가 있으면 true)
-
-      touchStart.sheetY = node.getBoundingClientRect().y;
-      if (e instanceof TouchEvent) {
-        touchStart.touchY = e.touches[0].clientY;
-      } else {
-        touchStart.touchY = e.clientY;
-      }
-
-      isDragging.current = true;
-      metrics.current.snap =
-        touchStart.sheetY + (node.getBoundingClientRect().height / 4) * 1;
-    };
-
-    const handleTouchMove = (e: TouchEvent | MouseEvent) => {
-      const { touchStart, isContentAreaTouched } = metrics.current;
-
-      if (!isDragging.current) return;
-      let currentTouch;
-      if (e instanceof TouchEvent) {
-        currentTouch = e.touches[0];
-      } else {
-        currentTouch = e;
-      }
-      if (!isContentAreaTouched) {
-        e.preventDefault();
-        const touchOffset = currentTouch.clientY - touchStart.touchY;
-        node.style.setProperty(
-          'transform',
-          `translateY(${Math.max(touchOffset, 0)}px)`
-        );
-      }
-    };
-
-    // 손가락을 뗐을 때의 높이에 따라 닫을지 말지 결정
-    const handleTouchEnd = () => {
-      const { touchStart, snap } = metrics.current;
-      const currentY = node.getBoundingClientRect().y;
-
-      if (currentY > snap) {
-        node.style.setProperty(
-          'transform',
-          `translateY(${window.innerHeight - touchStart.sheetY}px)`
-        );
-        onClose();
-      } else if (currentY < snap) {
-        node.style.setProperty('transform', 'translateY(0px)');
-      }
-
-      isDragging.current = false;
-      metrics.current.isContentAreaTouched = false;
-    };
-
-    node.addEventListener('touchstart', handleTouchStart);
-    node.addEventListener('touchmove', handleTouchMove);
-    node.addEventListener('touchend', handleTouchEnd);
-    node.addEventListener('mousedown', handleTouchStart);
-    node.addEventListener('mousemove', handleTouchMove);
-    node.addEventListener('mouseup', handleTouchEnd);
-
-    return () => {
-      node.removeEventListener('touchstart', handleTouchStart);
-      node.removeEventListener('touchmove', handleTouchMove);
-      node.removeEventListener('touchend', handleTouchEnd);
-      node.removeEventListener('mousedown', handleTouchStart);
-      node.removeEventListener('mousemove', handleTouchMove);
-      node.removeEventListener('mouseup', handleTouchEnd);
-    };
-  }, [isBottomSheetOpen]);
+  useBottomSheetGesture({ isBottomSheetOpen, handleBarRef, onClose });
 
   return (
     <ModalPortal>
@@ -156,7 +43,7 @@ const BottomSheet = ({
             ref={handleBarRef}
           >
             {/* 바텀 시트 헤더 */}
-            <div className="flex w-full justify-center rounded-t-[12px] pt-2 pb-4">
+            <div className="flex w-full cursor-pointer justify-center rounded-t-[12px] pt-2 pb-4">
               <div className="bg-grey02 h-1 w-12 rounded-[2px]" />
             </div>
             {/* 바텀 시트 콘텐츠 */}

--- a/src/hooks/useBottomSheetGesture.ts
+++ b/src/hooks/useBottomSheetGesture.ts
@@ -1,0 +1,131 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+type BottomSheetMetrics = {
+  touchStart: {
+    sheetY: number; // 바텀 시트 초기 위치
+    touchY: number; // 사용자가 터치한 위치
+  };
+  snap: number; // 바텀 시트가 닫히는 기준 위치
+  isContentAreaTouched: boolean;
+};
+
+type useBottomSheetGestureProps = {
+  isBottomSheetOpen: boolean;
+  handleBarRef: RefObject<HTMLDivElement | null>;
+  onClose: () => void;
+};
+
+const useBottomSheetGesture = ({
+  isBottomSheetOpen,
+  handleBarRef,
+  onClose,
+}: useBottomSheetGestureProps) => {
+  const metrics = useRef<BottomSheetMetrics>({
+    touchStart: {
+      sheetY: 0,
+      touchY: 0,
+    },
+    snap: 0,
+    isContentAreaTouched: false,
+  });
+  // 스크롤 가능한 부모 요소를 찾음
+  const findScrollableParentElement = (
+    element: HTMLElement | null
+  ): HTMLElement | null => {
+    while (element) {
+      const overflowY = getComputedStyle(element).overflowY;
+      const isScrollable = element.scrollHeight > element.clientHeight;
+      if (isScrollable && overflowY !== 'hidden') {
+        return element;
+      }
+      element = element.parentElement;
+    }
+    return null;
+  };
+
+  useEffect(() => {
+    if (!isBottomSheetOpen) return;
+    if (!handleBarRef) return;
+    const node = handleBarRef?.current;
+    if (!node) return;
+
+    const isDragging = { current: false };
+
+    const handleTouchStart = (e: TouchEvent | MouseEvent) => {
+      const { touchStart } = metrics.current;
+
+      const target = e.target as HTMLElement;
+      const isScrollable = findScrollableParentElement(target);
+
+      metrics.current.isContentAreaTouched = !!isScrollable; // boolean으로 명시적 반환(요소가 있으면 true)
+
+      touchStart.sheetY = node.getBoundingClientRect().y;
+      if (e instanceof TouchEvent) {
+        touchStart.touchY = e.touches[0].clientY;
+      } else {
+        touchStart.touchY = e.clientY;
+      }
+
+      isDragging.current = true;
+      metrics.current.snap =
+        touchStart.sheetY + (node.getBoundingClientRect().height / 4) * 1;
+    };
+
+    const handleTouchMove = (e: TouchEvent | MouseEvent) => {
+      const { touchStart, isContentAreaTouched } = metrics.current;
+
+      if (!isDragging.current) return;
+      let currentTouch;
+      if (e instanceof TouchEvent) {
+        currentTouch = e.touches[0];
+      } else {
+        currentTouch = e;
+      }
+      if (!isContentAreaTouched) {
+        e.preventDefault();
+        const touchOffset = currentTouch.clientY - touchStart.touchY;
+        node.style.setProperty(
+          'transform',
+          `translateY(${Math.max(touchOffset, 0)}px)`
+        );
+      }
+    };
+
+    // 손가락을 뗐을 때의 높이에 따라 닫을지 말지 결정
+    const handleTouchEnd = () => {
+      const { touchStart, snap } = metrics.current;
+      const currentY = node.getBoundingClientRect().y;
+
+      if (currentY > snap) {
+        node.style.setProperty(
+          'transform',
+          `translateY(${window.innerHeight - touchStart.sheetY}px)`
+        );
+        onClose();
+      } else if (currentY < snap) {
+        node.style.setProperty('transform', 'translateY(0px)');
+      }
+
+      isDragging.current = false;
+      metrics.current.isContentAreaTouched = false;
+    };
+
+    node.addEventListener('touchstart', handleTouchStart);
+    node.addEventListener('touchmove', handleTouchMove);
+    node.addEventListener('touchend', handleTouchEnd);
+    node.addEventListener('mousedown', handleTouchStart);
+    node.addEventListener('mousemove', handleTouchMove);
+    node.addEventListener('mouseup', handleTouchEnd);
+
+    return () => {
+      node.removeEventListener('touchstart', handleTouchStart);
+      node.removeEventListener('touchmove', handleTouchMove);
+      node.removeEventListener('touchend', handleTouchEnd);
+      node.removeEventListener('mousedown', handleTouchStart);
+      node.removeEventListener('mousemove', handleTouchMove);
+      node.removeEventListener('mouseup', handleTouchEnd);
+    };
+  }, [isBottomSheetOpen]);
+};
+
+export default useBottomSheetGesture;

--- a/src/pages/user/sellerProfile/SellerProfile.tsx
+++ b/src/pages/user/sellerProfile/SellerProfile.tsx
@@ -69,6 +69,12 @@ const SellerProfile = ({ children }: { children: ReactNode }) => {
       date: '2025.05.01',
       content: '부스터 프로 이번 반응이 너무 좋아서 이틀 연장하기로 했어요 ',
     },
+    {
+      id: 5,
+      title: '입접 이벤트🤔💕',
+      date: '2025.05.01',
+      content: '부스터 프로 이번 반응이 너무 좋아서 이틀 연장하기로 했어요 ',
+    },
   ];
 
   return (

--- a/src/pages/user/sellerProfile/SellerProfile.tsx
+++ b/src/pages/user/sellerProfile/SellerProfile.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { Tab, Tabs } from '@/components/common/Tab';
 import { PATH } from '@/routes/path';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -7,6 +7,7 @@ import {
   NoticeBanner,
   SellerProfileCard,
   SellerProfileHeader,
+  BottomSheet,
 } from '@/components';
 
 type NoticeType = {
@@ -24,6 +25,8 @@ const SellerProfile = ({ children }: { children: ReactNode }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { pathname } = location;
+
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
   // 임시 링크
   const LINKS = [
@@ -79,9 +82,45 @@ const SellerProfile = ({ children }: { children: ReactNode }) => {
         <NoticeBanner
           title={NOTICES[0]?.title}
           count={NOTICES?.length}
-          onClickNotice={() => {}}
+          onClickNotice={() => setIsBottomSheetOpen(true)}
         />
       </div>
+      {isBottomSheetOpen && (
+        <BottomSheet
+          onClose={() => setIsBottomSheetOpen(false)}
+          isBottomSheetOpen={isBottomSheetOpen}
+        >
+          <div className="flex flex-col items-center gap-7">
+            <h1 className="subhead-b text-grey10 w-full text-center">
+              공지사항
+            </h1>
+            <div className="scrollbar-hide flex h-[70vh] flex-col gap-4 overflow-y-auto pb-8">
+              {NOTICES?.length === 0 ? (
+                <div className="flex h-full items-center">
+                  <span className="body2-m text-grey06 pb-20">
+                    아직 등록된 공지가 없습니다.
+                  </span>
+                </div>
+              ) : (
+                NOTICES?.map((notice) => (
+                  <div
+                    key={notice.id}
+                    className="border-grey03 flex h-fit w-full flex-col gap-2 border-b px-5 pb-5"
+                  >
+                    <div className="flex flex-col">
+                      <h2 className="body1-m text-grey10">{notice.title}</h2>
+                      <span className="caption-m text-grey05">
+                        {notice.date}
+                      </span>
+                    </div>
+                    <p className="body2-r text-grey09">{notice.content}</p>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </BottomSheet>
+      )}
       <section className="divide-grey02 flex flex-col divide-y-[12px]">
         {/* 링크 */}
         <div className="scrollbar-hide flex items-start gap-[.625rem] self-stretch overflow-x-auto px-5 py-3">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -45,6 +45,10 @@
     @apply flex h-screen w-screen max-w-[40rem] min-w-[20rem] flex-1 flex-col justify-end bg-[rgba(0,0,0,0.6)] md:w-[28rem];
   }
 
+  .animate-slide-up {
+    animation: slide-up 350ms ease-out;
+  }
+
   *:focus {
     outline: none;
   }
@@ -113,24 +117,12 @@
     @apply text-[.625rem] leading-[140%] font-medium tracking-[-0.001em];
   }
 
-  @keyframes flash {
-    0% {
-      background-color: var(--color-neutral-300);
-      box-shadow:
-        32px 0 var(--color-neutral-300),
-        -32px 0 #fff;
+  @keyframes slide-up {
+    from {
+      transform: translateY(100%);
     }
-    50% {
-      background-color: #fff;
-      box-shadow:
-        32px 0 var(--color-neutral-300),
-        -32px 0 var(--color-neutral-300);
-    }
-    100% {
-      background-color: var(--color-neutral-300);
-      box-shadow:
-        32px 0 #fff,
-        -32px 0 var(--color-neutral-300);
+    to {
+      transform: translateY(0rem);
     }
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,7 +34,15 @@
 
 @layer components {
   body {
-    @apply bg-grey01 font-pretendard box-border flex justify-center text-black;
+    @apply bg-grey01 font-pretendard relative box-border flex justify-center text-black;
+  }
+
+  .modal {
+    @apply fixed inset-0 top-0 right-0 bottom-0 left-0 z-50 flex flex-1 flex-col items-center justify-center;
+  }
+
+  .modal-bg-layout {
+    @apply flex h-screen w-screen max-w-[40rem] min-w-[20rem] flex-1 flex-col justify-end bg-[rgba(0,0,0,0.6)] md:w-[28rem];
   }
 
   *:focus {


### PR DESCRIPTION
## 개요
<!-- 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

BottomSheet 컴포넌트 구현하고 유저뷰 공지사항에 적용했습니다.

## 관련 이슈
<!---- Resolves: #(Issue Number) -->

Resolves: #8

## PR 유형
어떤 변경 사항이 있나요?

- [x] ✨ 새로운 기능 추가

## 작업 내용
<!-- 작업 사항에 대한 설명을 적어주세요 -->

- BottomSheet 컴포넌트 구현
- BottomSheet 컴포넌트 애니메이션 추가
- BottomSheet 컴포넌트 유저뷰 공지사항에 적용

## 스크린샷/동영상
<!-- 작업물에 대한 스크린샷 혹은 동영상을 첨부해주세요 -->

https://github.com/user-attachments/assets/738d4cf6-f98d-4a88-a0c0-88c7f237fc08

## 공유사항
<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->
컴퓨터에서 작동하라고 MouseEvent도 추가했습니다!
피그마 보면 컴포넌트 자체에 pb-4가 있던데 그렇게 하면 여러모로 불편할 것 같고(보관/삭제 클릭 범위 등) 인스타의 Bottom Sheet 참고했는데 컴포넌트 자체 말고 Bottom Sheet content에 padding이 있는 형식 같아서 없앴습니다! 컴포넌트 사용 시 pb-4가 필요하다면 따로 작성해주셔야할 것 같습니다. 사용 예시는 제가 적용한거 보시고 사용하시면 됩니다!